### PR TITLE
Add Transition Nodes

### DIFF
--- a/src/SensorToFlowNetworkMain.java
+++ b/src/SensorToFlowNetworkMain.java
@@ -44,6 +44,7 @@ public class SensorToFlowNetworkMain extends Application {
 
         prettyPrint(network.getDataNodes(), "Generator Nodes   Coordinates");
         prettyPrint(network.getStorageNodes(), "Storage Nodes    Coordinates");
+        prettyPrint(network.getTransitionNodes(), "Transition Nodes Coordinates");
 
         System.out.printf("Network is connected: %b\n", network.isConnected());
         System.out.printf("Network is feasible: %b\n", network.isFeasible());
@@ -93,6 +94,11 @@ public class SensorToFlowNetworkMain extends Application {
         int packetsCount = keyboard.nextInt();
         keyboard.nextLine();
 
+        System.out.println("Please enter the number of Storage Nodes (s) to generate:");
+        System.out.print("s = ");
+        int sNodeCount = keyboard.nextInt();
+        keyboard.nextLine();
+
         System.out.println("Please enter the amount of packets (m) each Storage Node has:");
         System.out.print("m = ");
         int storageCount = keyboard.nextInt();
@@ -109,7 +115,7 @@ public class SensorToFlowNetworkMain extends Application {
         keyboard.nextLine();
         System.out.println();
 
-        return SensorNetwork.of(width, height, nodeCount, transmissionRange, gNodeCount, packetsCount, storageCount, minValue, maxValue);
+        return SensorNetwork.of(width, height, nodeCount, transmissionRange, gNodeCount, packetsCount, sNodeCount, storageCount, minValue, maxValue);
     }
 
     /**

--- a/src/com/grivera/generator/Network.java
+++ b/src/com/grivera/generator/Network.java
@@ -3,6 +3,7 @@ package com.grivera.generator;
 import com.grivera.generator.sensors.DataNode;
 import com.grivera.generator.sensors.SensorNode;
 import com.grivera.generator.sensors.StorageNode;
+import com.grivera.generator.sensors.TransitionNode;
 
 import java.util.List;
 import java.util.Map;
@@ -17,13 +18,63 @@ public interface Network {
     List<SensorNode> getSensorNodes();
     List<DataNode> getDataNodes();
     List<StorageNode> getStorageNodes();
+    List<TransitionNode> getTransitionNodes();
+
+    /**
+     * Tests whether all the nodes are directly or indirectly connected with each
+     * other.
+     *
+     * @return true if and only if all the nodes are directly or indirectly
+     *         connected
+     *         with each other; otherwise false
+     */
     boolean isConnected();
+
+    /**
+     * Tests whether there is enough storage for all the overflow packets in the
+     * network.
+     *
+     * @return true if and only if there is enough storage for all the overflow
+     *         packets in the network;
+     *         otherwise false
+     */
     boolean isFeasible();
     Map<SensorNode, Set<SensorNode>> getAdjacencyList();    // Returns the connection of nodes (using ID)
     int calculateMinCost(SensorNode from, SensorNode to);
+
+    /**
+     * Returns the sensor nodes in the min-cost path between the from and to sensor
+     * nodes
+     *
+     * @param from the starting sensor node
+     * @param to   the ending sensor node
+     * @return a list of the sensor nodes in the min-cost path between the from and
+     *         to sensor nodes
+     */
     List<SensorNode> getMinCostPath(SensorNode from, SensorNode to);
+
+    /**
+     * Calculates the cost of a given path.
+     *
+     * @param path the path between two sensor nodes
+     * @return the cost of the given path
+     */
     int calculateCostOfPath(List<SensorNode> path);
+
+    /**
+     * Saves the network into a .sn file format.
+     *
+     * @param fileName the path to the file to save to
+     */
     void save(String fileName);
+
+    /**
+     * Saves the network in the <b>DIMAC</b> format
+     * that can be used for the min-cost flow program
+     * <a href="https://github.com/iveney/cs2">CS2</a>.
+     *
+     * @param fileName the path to the file to save to
+     */
     void saveAsCsInp(String fileName);
     void setOverflowPackets(int overflowPackets);
     void setStorageCapacity(int storageCapacity);

--- a/src/com/grivera/generator/SensorNetwork.java
+++ b/src/com/grivera/generator/SensorNetwork.java
@@ -3,6 +3,7 @@ package com.grivera.generator;
 import com.grivera.generator.sensors.DataNode;
 import com.grivera.generator.sensors.SensorNode;
 import com.grivera.generator.sensors.StorageNode;
+import com.grivera.generator.sensors.TransitionNode;
 import com.grivera.util.Pair;
 import com.grivera.util.Tuple;
 
@@ -22,6 +23,7 @@ public class SensorNetwork implements Network {
     private List<SensorNode> nodes;
     private List<DataNode> dNodes;
     private List<StorageNode> sNodes;
+    private List<TransitionNode> tNodes;
     private Map<SensorNode, Set<SensorNode>> graph;
 
     private final Map<Pair<SensorNode, SensorNode>, Integer> costMap = new HashMap<>();
@@ -40,11 +42,12 @@ public class SensorNetwork implements Network {
      * @param tr the transmission range of the nodes (in meters)
      * @param p  the number of Data Nodes in the network
      * @param q  the number of data packets each Data Node has
+     * @param s  the number of Storage Nodes in the network
      * @param m  the storage capacity each Storage nodes has
      * @param Vl the minimum value of a data packet (inclusive)
      * @param Vh the maximum value of a data packet (inclusive)
      */
-    public SensorNetwork(double x, double y, int N, double tr, int p, int q, int m, int Vl, int Vh) {
+    public SensorNetwork(double x, double y, int N, double tr, int p, int q, int s, int m, int Vl, int Vh) {
         this.width = x;
         this.length = y;
         this.dataPacketCount = q;
@@ -52,13 +55,16 @@ public class SensorNetwork implements Network {
         this.transmissionRange = tr;
 
         /* Used to separate each type of node for later use and retrieval */
+        if (p + s > N) throw new IllegalArgumentException("Invalid SensorNetwork constructor parameters");
+
         this.dNodes = new ArrayList<>(p);
-        this.sNodes = new ArrayList<>(N - p);
+        this.sNodes = new ArrayList<>(s);
+        this.tNodes = new ArrayList<>(N - s - p);
 
         /*
          * Init the Sensor com.grivera.generator.Network to allow basic operations on it
          */
-        this.nodes = this.initNodes(N, p, Vl, Vh);
+        this.nodes = this.initNodes(N, p, s, Vl, Vh);
         this.graph = this.initGraph(this.nodes);
     }
 
@@ -114,10 +120,12 @@ public class SensorNetwork implements Network {
             SensorNode.resetCounter();
             StorageNode.resetCounter();
             DataNode.resetCounter();
+            TransitionNode.resetCounter();
 
-            this.nodes = new ArrayList<>(N);
-            this.sNodes = new ArrayList<>(N);
-            this.dNodes = new ArrayList<>(N);
+            this.nodes = new ArrayList<>();
+            this.sNodes = new ArrayList<>();
+            this.dNodes = new ArrayList<>();
+            this.tNodes = new ArrayList<>();
 
             String[] lineArgs;
             double x, y;
@@ -134,17 +142,23 @@ public class SensorNetwork implements Network {
 
                 // Requires JDK 12+
                 node = switch (lineArgs[0]) {
-                    case "d" -> new DataNode(x, y, this.transmissionRange, this.dataPacketCount, Integer.parseInt(lineArgs[3]));
+                    case "d" ->
+                            new DataNode(x, y, this.transmissionRange, this.dataPacketCount, Integer.parseInt(lineArgs[3]));
                     case "s" ->
                         new StorageNode(x, y, this.transmissionRange, this.storageCapacity);
-                    default -> throw new IOException();
+                    case "t" ->
+                            new TransitionNode(x, y, this.transmissionRange);
+                    default ->
+                            throw new IOException();
                 };
 
                 this.nodes.add(node);
                 if (node instanceof DataNode) {
                     this.dNodes.add((DataNode) node);
-                } else {
+                } else if (node instanceof StorageNode) {
                     this.sNodes.add((StorageNode) node);
+                } else {
+                    this.tNodes.add((TransitionNode) node);
                 }
                 lineNumber++;
             }
@@ -154,11 +168,11 @@ public class SensorNetwork implements Network {
         }
     }
 
-    public static SensorNetwork of(double x, double y, int N, double tr, int p, int q, int m, int Vl, int Vh) {
+    public static SensorNetwork of(double x, double y, int N, double tr, int p, int q, int s, int m, int Vl, int Vh) {
         SensorNetwork network;
         int attempts = 0;
         do {
-            network = new SensorNetwork(x, y, N, tr, p, q, m, Vl, Vh);
+            network = new SensorNetwork(x, y, N, tr, p, q, s, m, Vl, Vh);
 
             /* Checks if the parameters in the program are feasible */
             if (!network.isFeasible()) {
@@ -195,7 +209,7 @@ public class SensorNetwork implements Network {
         return sn;
     }
 
-    private List<SensorNode> initNodes(int nodeCount, int p, int Vl, int Vh) {
+    private List<SensorNode> initNodes(int nodeCount, int p, int s, int Vl, int Vh) {
         List<SensorNode> nodes = new ArrayList<>(nodeCount);
         Random rand = new Random();
 
@@ -203,6 +217,7 @@ public class SensorNetwork implements Network {
         SensorNode.resetCounter();
         StorageNode.resetCounter();
         DataNode.resetCounter();
+        TransitionNode.resetCounter();
 
         /* Choose p random nodes to be Generator Nodes, the rest are Storage Nodes */
         int choice;
@@ -216,13 +231,17 @@ public class SensorNetwork implements Network {
 
             tmpVal = rand.nextInt(Vh - Vl + 1) + Vl;
 
-            if ((choice < 5 && p > 0) || nodeCount - index <= p) {
+            if ((choice < 4 && p > 0) || nodeCount - index <= p) {
                 tmp = new DataNode(x, y, this.transmissionRange, this.dataPacketCount, tmpVal);
                 this.dNodes.add((DataNode) tmp);
                 p--;
-            } else {
+            } else if ((choice < 8 && s > 0) || nodeCount - index - p - s <= 0) {
                 tmp = new StorageNode(x, y, this.transmissionRange, this.storageCapacity);
                 this.sNodes.add((StorageNode) tmp);
+                s--;
+            } else {
+                tmp = new TransitionNode(x, y, this.transmissionRange);
+                this.tNodes.add((TransitionNode) tmp);
             }
             nodes.add(tmp);
         }
@@ -277,13 +296,13 @@ public class SensorNetwork implements Network {
         return Collections.unmodifiableList(this.sNodes);
     }
 
+    @Override
+    public List<TransitionNode> getTransitionNodes() {
+        return Collections.unmodifiableList(this.tNodes);
+    }
+
     /**
-     * Tests whether all the nodes are directly or indirectly connected with each
-     * other.
-     *
-     * @return true if and only if all the nodes are directly or indirectly
-     *         connected
-     *         with each other; otherwise false
+     * {@inheritDoc}
      */
     @Override
     public boolean isConnected() {
@@ -291,12 +310,7 @@ public class SensorNetwork implements Network {
     }
 
     /**
-     * Tests whether there is enough storage for all the overflow packets in the
-     * network.
-     *
-     * @return true if and only if there is enough storage for all the overflow
-     *         packets in the network;
-     *         otherwise false
+     * {@inheritDoc}
      */
     @Override
     public boolean isFeasible() {
@@ -322,13 +336,7 @@ public class SensorNetwork implements Network {
     }
 
     /**
-     * Returns the sensor nodes in the min-cost path between the from and to sensor
-     * nodes
-     *
-     * @param from the starting sensor node
-     * @param to   the ending sensor node
-     * @return a list of the sensor nodes in the min-cost path between the from and
-     *         to sensor nodes
+     * {@inheritDoc}
      */
     @Override
     public List<SensorNode> getMinCostPath(SensorNode from, SensorNode to) {
@@ -336,10 +344,7 @@ public class SensorNetwork implements Network {
     }
 
     /**
-     * Calculates the cost of a given path.
-     * 
-     * @param path the path between two sensor nodes
-     * @return the cost of the given path
+     * {@inheritDoc}
      */
     @Override
     public int calculateCostOfPath(List<SensorNode> path) {
@@ -351,9 +356,7 @@ public class SensorNetwork implements Network {
     }
 
     /**
-     * Saves the network into a .sn file format.
-     *
-     * @param fileName the path to the file to save to
+     * {@inheritDoc}
      */
     @Override
     public void save(String fileName) {
@@ -367,8 +370,10 @@ public class SensorNetwork implements Network {
             for (SensorNode n : this.nodes) {
                 if (n instanceof DataNode dn) {         // JDK 15+ feature
                     pw.printf("%c %f %f %d\n", 'd', dn.getX(), dn.getY(), dn.getOverflowPacketValue());
-                } else {
+                } else if (n instanceof StorageNode) {
                     pw.printf("%c %f %f\n", 's', n.getX(), n.getY());
+                } else {
+                    pw.printf("%c %f %f\n", 't', n.getX(), n.getY());
                 }
             }
             System.out.printf("Saved sensor network in file \"%s\"!\n", fileName);
@@ -405,18 +410,14 @@ public class SensorNetwork implements Network {
     }
 
     /**
-     * Saves the network in the <b>DIMAC</b> format
-     * that can be used for the min-cost flow program
-     * <a href="https://github.com/iveney/cs2">CS2</a>.
-     *
-     * @param fileName the path to the file to save to
+     * {@inheritDoc}
      */
     @Override
     public void saveAsCsInp(String fileName) {
         final int supply = this.dataPacketCount * this.dNodes.size();
         final int demand = -supply;
 
-        final int totalNodes = this.nodes.size() + 3;
+        final int totalNodes = this.dNodes.size() + this.sNodes.size() + 3;
         final int totalEdges = this.getEdgeCount();
 
         File file = new File(fileName);

--- a/src/com/grivera/generator/SensorNetworkGraph.java
+++ b/src/com/grivera/generator/SensorNetworkGraph.java
@@ -2,6 +2,7 @@ package com.grivera.generator;
 
 import com.grivera.generator.sensors.DataNode;
 import com.grivera.generator.sensors.SensorNode;
+import com.grivera.generator.sensors.StorageNode;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.Canvas;
@@ -129,8 +130,10 @@ public class SensorNetworkGraph extends Pane {
         for (SensorNode node : network.getSensorNodes()) {
             if (node instanceof DataNode) {
                 this.gc.setStroke(Color.RED);
-            } else {
+            } else if (node instanceof StorageNode) {
                 this.gc.setStroke(Color.GREEN);
+            } else {
+                this.gc.setStroke(Color.GRAY);
             }
             this.drawNode(node, 8, true);
         }
@@ -166,6 +169,7 @@ public class SensorNetworkGraph extends Pane {
                 String.join(" -> ",
                         path.stream().map(SensorNode::getName).toArray(CharSequence[]::new)));
         System.out.printf("Cost of Path: %d micro J\n", this.network.calculateCostOfPath(path));
+        System.out.printf("Profit of Path: %d micro J\n", this.network.calculateProfitOf((DataNode) from, (StorageNode) to));
 
         this.gc.beginPath();
         this.gc.setStroke(Color.DARKORANGE);

--- a/src/com/grivera/generator/sensors/DataNode.java
+++ b/src/com/grivera/generator/sensors/DataNode.java
@@ -55,11 +55,6 @@ public class DataNode extends SensorNode {
         return this.packetsLeft;
     }
 
-    @Override
-    public int calculateStorageCost() {
-        return 0;
-    }
-
     public int getOverflowPacketValue() {
         return this.overflowPacketsValue;
     }

--- a/src/com/grivera/generator/sensors/SensorNode.java
+++ b/src/com/grivera/generator/sensors/SensorNode.java
@@ -87,8 +87,6 @@ public abstract class SensorNode {
         return (int) Math.round(cost * Math.pow(10, 6));
     }
 
-    public abstract int calculateStorageCost();
-
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof SensorNode sn)) {

--- a/src/com/grivera/generator/sensors/StorageNode.java
+++ b/src/com/grivera/generator/sensors/StorageNode.java
@@ -59,7 +59,6 @@ public class StorageNode extends SensorNode {
         return this.capacity - this.usedSpace;
     }
 
-    @Override
     public int calculateStorageCost() {
         double cost = this.usedSpace * BITS_PER_PACKET * E_store;
         return (int) Math.round(cost * Math.pow(10, 6));

--- a/src/com/grivera/generator/sensors/TransitionNode.java
+++ b/src/com/grivera/generator/sensors/TransitionNode.java
@@ -1,0 +1,16 @@
+package com.grivera.generator.sensors;
+
+public class TransitionNode extends SensorNode {
+    private static int idCounter = 1;
+
+    public TransitionNode(double x, double y, double tr) {
+        super(x, y, tr, String.format("TN%02d", idCounter++));
+    }
+
+    @Override
+    public void resetPackets() { /* Do Nothing */ }
+
+    public static void resetCounter() {
+        idCounter = 1;
+    }
+}


### PR DESCRIPTION
This pull requests allows the user to specify the number of DNs and SNs out of the total nodes to allow in the network. Any nodes that aren't DNs or SNs will be called Transition Nodes and be colors grey in the GUI.

These Transitions Nodes do not have available storage space. These nodes can only help relay data packets, but can not store packets in themselves for long periods of time.